### PR TITLE
Tweaks to make theatre work for Duffel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ WORKDIR /go/src/github.com/gocardless/theatre
 COPY . /go/src/github.com/gocardless/theatre
 RUN make VERSION=$(cat VERSION) build
 
-# Clone our fork of envconsul and build it
-RUN set -x \
-      && git clone https://github.com/gocardless/envconsul.git \
-      && cd envconsul \
-      && git checkout 2eb7fdc4dd1a13464e9a529e324ffd9b8d12ce25 \
-      && make linux/amd64 \
-      && mv pkg/linux_amd64/envconsul ../bin
+# NOTE: We don't need envconsul, as we dont yet run Vault.
+# # Clone our fork of envconsul and build it
+# RUN set -x \
+#       && git clone https://github.com/gocardless/envconsul.git \
+#       && cd envconsul \
+#       && git checkout 2eb7fdc4dd1a13464e9a529e324ffd9b8d12ce25 \
+#       && make linux/amd64 \
+#       && mv pkg/linux_amd64/envconsul ../bin
 
 # Use ubuntu as our base package to enable generic system tools
 FROM ubuntu:bionic-20191202

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -9,13 +9,14 @@ commonLabels:
   app: theatre
 
 resources:
+  - managers/namespace.yaml
   - crds/rbac_v1alpha1_directoryrolebinding.yaml
   - crds/workloads_v1alpha1_console.yaml
   - crds/workloads_v1alpha1_consoletemplate.yaml
-  - managers/namespace.yaml
   - managers/rbac.yaml
-  - managers/vault.yaml
   - managers/workloads.yaml
+  # NOTE: Avoid this as we don't use vault, yet
+  # - managers/vault.yaml
 
 vars:
   # We want our mutating webhook to ensure it only ever configures pods to use
@@ -23,10 +24,10 @@ vars:
   # worry about maintaining compatibility between versions of the webhook and
   # theatre-envconsul, as both will use the same version and be deployed
   # atomically.
-  - name: THEATRE_IMAGE
-    objref:
-      apiVersion: apps/v1
-      kind: StatefulSet
-      name: vault-manager
-    fieldref:
-      fieldpath: spec.template.spec.containers[0].image
+  # - name: THEATRE_IMAGE
+  #   objref:
+  #     apiVersion: apps/v1
+  #     kind: StatefulSet
+  #     name: vault-manager
+  #   fieldref:
+  #     fieldpath: spec.template.spec.containers[0].image

--- a/config/base/managers/rbac.yaml
+++ b/config/base/managers/rbac.yaml
@@ -80,7 +80,7 @@ spec:
           args:
             - --google  # enable GoogleGroup resolution
             - --metrics-address=0.0.0.0
-          image: eu.gcr.io/gc-containers/gocardless/theatre:latest
+          image: gcr.io/duffel-shared/theatre:latest
           imagePullPolicy: Always
           name: manager
           env:

--- a/config/base/managers/vault.yaml
+++ b/config/base/managers/vault.yaml
@@ -100,7 +100,7 @@ spec:
             - $(THEATRE_IMAGE)
             - --metrics-address
             - 0.0.0.0
-          image: eu.gcr.io/gc-containers/gocardless/theatre:latest
+          image: gcr.io/duffel-shared/theatre:latest
           name: manager
           env:
             - name: POD_NAMESPACE

--- a/config/base/managers/workloads.yaml
+++ b/config/base/managers/workloads.yaml
@@ -111,7 +111,7 @@ spec:
             - /usr/local/bin/workloads-manager
           args:
             - --metrics-address=0.0.0.0
-          image: eu.gcr.io/gc-containers/gocardless/theatre:latest
+          image: gcr.io/duffel-shared/theatre:latest
           imagePullPolicy: Always
           name: manager
           env:


### PR DESCRIPTION
Minor tweaks to make theatre work for Duffel, these include:

1. Removing references and resources for Vault, since we don't use it
2. Replacing the container image used, since we need to use our registry